### PR TITLE
"avslutning.steg.forsteside.tittel": "avslutning.steg.forsteside.pdf.tittel":  

### DIFF
--- a/src/sprak/tekster/nb.ts
+++ b/src/sprak/tekster/nb.ts
@@ -24,7 +24,7 @@ export default {
   "avslutning.steg.lastned.knapp.download": `Laster ned`,
   "avslutning.steg.forsteside.tittel": `Last ned "Førsteside til saken din"`,
   "avslutning.steg.forsteside.pdf.tittel": `Førsteside`,
-  "avslutning.steg.forsteside.beskrivelse": `Dette forsidearket inneholder viktig informasjon om hvilken <b>enhet</b> i NAV som skal motta dokumentasjonen. Den inneholder også adressen du skal sende dokumentene til.`,
+  "avslutning.steg.forsteside.beskrivelse": `Dette førstesidearket inneholder viktig informasjon om hvilken <b>enhet</b> i NAV som skal motta dokumentasjonen. Den inneholder også adressen du skal sende dokumentene til.`,
   "avslutning.steg.forsteside.nedlastingsfeil": `Noe gikk feil. Prøv igjen senere. Vi arbeider med å rette feilen.`,
   "avslutning.steg.forsteside.nedlastingsfeil.hotjartrigger": `Hjelp oss å forstå hva feilen er.`,
   "avslutning.steg.nedlasting.skjema.tittel": `Last ned skjema {skjemanummer}`,


### PR DESCRIPTION
"avslutning.steg.forsteside.pdf.tittel": `Førsteside`,
  "avslutning.steg.forsteside.beskrivelse": `Dette førstesidearket inneholder viktig informasjon om hvilken <b>enhet</b> i NAV som skal motta dokumentasjonen. Den inneholder også adressen du skal sende dokumentene til.`,