### PR TITLE
Bruk samme kode for å generere titler for vedlegg uansett.

### DIFF
--- a/src/sider/3-soknadstilpasser/ettersendelse/Ettersendelse.tsx
+++ b/src/sider/3-soknadstilpasser/ettersendelse/Ettersendelse.tsx
@@ -5,7 +5,7 @@ import { Store } from "../../../typer/store";
 import { Soknadsobjekt } from "../../../typer/soknad";
 import { Vedleggsobjekt } from "../../../typer/skjemaogvedlegg";
 import { connect } from "react-redux";
-import Sjekkbokser from "../felles/velgvedlegg/Sjekkbokser";
+import {Sjekkbokser} from "../felles/velgvedlegg/Sjekkbokser";
 import Underbanner from "../../../komponenter/bannere/Underbanner";
 import Personalia from "../felles/personalia/Personalia";
 import Steg from "../../../komponenter/bannere/Steg";

--- a/src/sider/3-soknadstilpasser/felles/velgvedlegg/Sjekkbokser.tsx
+++ b/src/sider/3-soknadstilpasser/felles/velgvedlegg/Sjekkbokser.tsx
@@ -1,12 +1,11 @@
 import React, {SyntheticEvent} from "react";
-import {injectIntl, InjectedIntlProps} from "react-intl";
+import {InjectedIntlProps, injectIntl} from "react-intl";
 import {Vedleggsobjekt} from "typer/skjemaogvedlegg";
 import {Dispatch} from "redux";
-import {toggleInnsendingVedlegg} from "states/reducers/vedlegg";
-import {toggleValgtVedleggForSjekkbokser} from "states/reducers/vedlegg";
+import {toggleInnsendingVedlegg, toggleValgtVedleggForSjekkbokser} from "states/reducers/vedlegg";
 import {Store} from "typer/store";
 import {Soknadsobjekt} from "typer/soknad";
-import {withRouter, RouteComponentProps} from "react-router";
+import {RouteComponentProps, withRouter} from "react-router";
 import {connect} from "react-redux";
 import PanelBase from "nav-frontend-paneler";
 import CheckboksPanelGruppe from "nav-frontend-skjema/lib/checkboks-panel-gruppe";
@@ -33,29 +32,57 @@ const sjekkboksPanelPropsForVedlegg = (vedleggsobjekt: Vedleggsobjekt, locale: s
   };
 }
 
-const createChangeHandler = (toggleFunc: ToggleFunc, soknadsobjekt: Soknadsobjekt) => {
-  return (
-    event: SyntheticEvent<EventTarget, Event>,
-    value?: string
-  ) => value && toggleFunc(value, soknadsobjekt._id);
-}
-
-const lagCheckboks = (vedleggsobjekt: Vedleggsobjekt, valgteVedlegg: Vedleggsobjekt[], soknadsobjekt: Soknadsobjekt, locale: string) => {
-  const markert = valgteVedlegg
-    .filter(v => v._key === vedleggsobjekt._key)
-    .filter(v => v.soknadsobjektId === soknadsobjekt._id)
-    .filter(v => v.skalSendes)
-    .shift();
-  return sjekkboksPanelPropsForVedlegg(vedleggsobjekt, locale, !!markert);
-};
-
-const skalSendes = (vedleggsobjekt: Vedleggsobjekt, valgteVedlegg: Vedleggsobjekt[], soknadsobjekt: Soknadsobjekt) => {
-  const markert = valgteVedlegg
-    .filter(v => v._key === vedleggsobjekt._key)
-    .filter(v => v.soknadsobjektId === soknadsobjekt._id)
-    .filter(v => v.skalSendes)
-    .shift();
-  return !!markert;
+const createVedleggsContext = (valgteVedlegg: Vedleggsobjekt[], soknadsobjekt: Soknadsobjekt, locale: string) => {
+  const result = {
+    createChangeHandler: (toggleFunc: ToggleFunc) => {
+      return (
+        event: SyntheticEvent<EventTarget, Event>,
+        value?: string
+      ) => value && toggleFunc(value, soknadsobjekt._id);
+    },
+    paakrevdeVedlegg: () => {
+      return result.vedleggTilSoknad().filter(v => v.pakrevd);
+    },
+    ikkePaakrevdeVedlegg: () => {
+      return result.vedleggTilSoknad().filter(v => !v.pakrevd);
+    },
+    vedleggTilSoknad: () => {
+      return soknadsobjekt.vedleggtilsoknad || [];
+    },
+    manglerVedlegg: () => {
+      if (result.vedleggTilSoknad().length < 1) {
+        return null;
+      }
+    },
+    skalVedleggetSendes: (vedleggsobjekt: Vedleggsobjekt) => {
+      return !!(valgteVedlegg
+        .filter(v => v._key === vedleggsobjekt._key)
+        .filter(v => v.soknadsobjektId === soknadsobjekt._id)
+        .filter(v => v.skalSendes)
+        .shift());
+    },
+    skalVedleggetIkkeEttersendes: (vedleggsobjekt: Vedleggsobjekt) => {
+      return !!(valgteVedlegg
+        .filter(v => v._key === vedleggsobjekt._key)
+        .filter(v => v.soknadsobjektId === soknadsobjekt._id)
+        .filter(v => !v.skalEttersendes)
+        .shift());
+    },
+    lagCheckboksForVedlegg: (vedleggsobjekt: Vedleggsobjekt) => {
+      return sjekkboksPanelPropsForVedlegg(
+        vedleggsobjekt,
+        locale,
+        result.skalVedleggetSendes(vedleggsobjekt));
+    },
+    // påkrevde vedlegg i egen bolk
+    lagEgenCheckboksForPakrevdeVedlegg: (vedleggsobjekt: Vedleggsobjekt) => {
+      return sjekkboksPanelPropsForVedlegg(
+        vedleggsobjekt,
+        locale,
+        result.skalVedleggetIkkeEttersendes(vedleggsobjekt));
+    }
+  }
+  return result;
 }
 
 
@@ -66,23 +93,57 @@ const Sjekkbokser = ({
                        valgteVedlegg,
                        toggleValgtVedleggForSjekkbokser,
                      }: MergedProps) => {
-  const vedleggTilSoknad = soknadsobjekt.vedleggtilsoknad || [];
-  if (vedleggTilSoknad.length < 1) {
+  const vedleggsContext = createVedleggsContext(valgteVedlegg, soknadsobjekt, intl.locale);
+  if (vedleggsContext.manglerVedlegg()) {
     return null;
   }
   return (
     <PanelBase className="seksjon">
       <CheckboksPanelGruppe
         legend=""
-        checkboxes={vedleggTilSoknad.map(vedlegg => sjekkboksPanelPropsForVedlegg(
-          vedlegg,
-          intl.locale,
-          skalSendes(vedlegg, valgteVedlegg, soknadsobjekt)))}
-        onChange={createChangeHandler(toggleValgtVedleggForSjekkbokser, soknadsobjekt)}
+        checkboxes={vedleggsContext.vedleggTilSoknad().map(vedleggsContext.lagCheckboksForVedlegg)}
+        onChange={vedleggsContext.createChangeHandler(toggleValgtVedleggForSjekkbokser)}
       />
     </PanelBase>
   );
 };
+
+const SjekkbokserMedUtskiltePaakrevde = (props: MergedProps) => {
+  const {
+    intl,
+    soknadsobjekt,
+    valgteVedlegg,
+    toggleValgtVedleggForSjekkbokser,
+    toggleInnsendingVedlegg
+  } = props;
+  const vedleggsContext = createVedleggsContext(valgteVedlegg, soknadsobjekt, intl.locale);
+  if (vedleggsContext.manglerVedlegg()) {
+    return null;
+  }
+  if (vedleggsContext.paakrevdeVedlegg().length < 1) {
+    return <Sjekkbokser {...props} />;
+  }
+  return (
+    <PanelBase className="seksjon">
+      <CheckboksPanelGruppe
+        className="sjekkbokser__panelgruppe"
+        legend={intl.formatMessage({id: "sjekkbokser.pakrevde"})}
+        checkboxes={vedleggsContext.paakrevdeVedlegg()
+          .map(vedleggsContext.lagEgenCheckboksForPakrevdeVedlegg)}
+        onChange={vedleggsContext.createChangeHandler(toggleInnsendingVedlegg)}
+      />
+      <CheckboksPanelGruppe
+        legend={intl.formatMessage({
+          id: "sjekkbokser.situasjonsbestemte"
+        })}
+        checkboxes={vedleggsContext.ikkePaakrevdeVedlegg()
+          .map(vedleggsContext.lagCheckboksForVedlegg)}
+        onChange={vedleggsContext.createChangeHandler(toggleValgtVedleggForSjekkbokser)}
+      />
+    </PanelBase>
+  );
+};
+
 
 const mapStateToProps = (store: Store) => ({
   valgteVedlegg: store.vedlegg.valgteVedlegg
@@ -94,57 +155,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   toggleInnsendingVedlegg: (_key: string, soknadsobjektId: string) =>
     dispatch(toggleInnsendingVedlegg(_key, soknadsobjektId))
 });
-
-const SjekkbokserMedUtskiltePaakrevde = (props: MergedProps) => {
-  const {
-    intl,
-    soknadsobjekt,
-    valgteVedlegg,
-    toggleValgtVedleggForSjekkbokser,
-    toggleInnsendingVedlegg
-  } = props;
-  const vedleggTilSoknad = soknadsobjekt.vedleggtilsoknad || [];
-  if (vedleggTilSoknad.length < 1) {
-    return null;
-  }
-  const pakrevde = vedleggTilSoknad.filter(v => v.pakrevd);
-  if (pakrevde.length < 1) {
-    return <Sjekkbokser {...props} />;
-  }
-  // Dersom påkrevde vedlegg er i egen bolk
-  const lagEgenCheckboksForPakrevdeVedlegg = (
-    vedleggsobjekt: Vedleggsobjekt
-  ) => {
-    const markert = valgteVedlegg
-      .filter(v => v._key === vedleggsobjekt._key)
-      .filter(v => v.soknadsobjektId === soknadsobjekt._id)
-      .filter(v => !v.skalEttersendes)
-      .shift();
-    return sjekkboksPanelPropsForVedlegg(vedleggsobjekt, intl.locale, !!markert);
-  };
-
-  return (
-    <PanelBase className="seksjon">
-      <CheckboksPanelGruppe
-        className="sjekkbokser__panelgruppe"
-        legend={intl.formatMessage({id: "sjekkbokser.pakrevde"})}
-        checkboxes={vedleggTilSoknad
-          .filter(v => v.pakrevd)
-          .map(vedlegg => lagEgenCheckboksForPakrevdeVedlegg(vedlegg))}
-        onChange={createChangeHandler(toggleInnsendingVedlegg, soknadsobjekt)}
-      />
-      <CheckboksPanelGruppe
-        legend={intl.formatMessage({
-          id: "sjekkbokser.situasjonsbestemte"
-        })}
-        checkboxes={vedleggTilSoknad
-          .filter(v => !v.pakrevd)
-          .map(vedlegg => lagCheckboks(vedlegg, valgteVedlegg, soknadsobjekt, intl.locale))}
-        onChange={createChangeHandler(toggleValgtVedleggForSjekkbokser, soknadsobjekt)}
-      />
-    </PanelBase>
-  );
-};
 
 
 const WrappedSjekkBokserMedUtskiltePaakrevde = injectIntl<Props & InjectedIntlProps>(

--- a/src/sider/3-soknadstilpasser/felles/velgvedlegg/Sjekkbokser.tsx
+++ b/src/sider/3-soknadstilpasser/felles/velgvedlegg/Sjekkbokser.tsx
@@ -14,15 +14,13 @@ import {localeVedleggstittel} from "utils/soknadsobjekter";
 
 interface Props {
   soknadsobjekt: Soknadsobjekt;
-  skillUtPakrevde?: boolean;
 }
+
+type ToggleFunc = (_key: string, soknadsobjektId: string) => void;
 
 interface ReduxProps {
   valgteVedlegg: Vedleggsobjekt[];
-  toggleValgtVedleggForSjekkbokser: (
-    _key: string,
-    soknadsobjektId: string
-  ) => void;
+  toggleValgtVedleggForSjekkbokser: ToggleFunc;
   toggleInnsendingVedlegg: (_key: string, soknadsobjektId: string) => void;
 }
 
@@ -35,83 +33,55 @@ const sjekkboksPanelPropsForVedlegg = (vedleggsobjekt: Vedleggsobjekt, locale: s
   };
 }
 
+const createChangeHandler = (toggleFunc: ToggleFunc, soknadsobjekt: Soknadsobjekt) => {
+  return (
+    event: SyntheticEvent<EventTarget, Event>,
+    value?: string
+  ) => value && toggleFunc(value, soknadsobjekt._id);
+}
+
+const lagCheckboks = (vedleggsobjekt: Vedleggsobjekt, valgteVedlegg: Vedleggsobjekt[], soknadsobjekt: Soknadsobjekt, locale: string) => {
+  const markert = valgteVedlegg
+    .filter(v => v._key === vedleggsobjekt._key)
+    .filter(v => v.soknadsobjektId === soknadsobjekt._id)
+    .filter(v => v.skalSendes)
+    .shift();
+  return sjekkboksPanelPropsForVedlegg(vedleggsobjekt, locale, !!markert);
+};
+
+const skalSendes = (vedleggsobjekt: Vedleggsobjekt, valgteVedlegg: Vedleggsobjekt[], soknadsobjekt: Soknadsobjekt) => {
+  const markert = valgteVedlegg
+    .filter(v => v._key === vedleggsobjekt._key)
+    .filter(v => v.soknadsobjektId === soknadsobjekt._id)
+    .filter(v => v.skalSendes)
+    .shift();
+  return !!markert;
+}
+
+
 type MergedProps = Props & InjectedIntlProps & RouteComponentProps & ReduxProps;
 const Sjekkbokser = ({
                        intl,
                        soknadsobjekt,
                        valgteVedlegg,
                        toggleValgtVedleggForSjekkbokser,
-                       toggleInnsendingVedlegg,
-                       skillUtPakrevde
                      }: MergedProps) => {
-  const handleOnChange = (
-    event: SyntheticEvent<EventTarget, Event>,
-    value?: string
-  ) => value && toggleValgtVedleggForSjekkbokser(value, soknadsobjekt._id);
-
-  // Dersom påkrevde vedlegg er i egen bolk
-  const handleOnChangePakrevdeVedlegg = (
-    event: SyntheticEvent<EventTarget, Event>,
-    value?: string
-  ) => {
-    value && toggleInnsendingVedlegg(value, soknadsobjekt._id);
-  };
-
-  // Dersom påkrevde vedlegg er i egen bolk
-  const lagEgenCheckboksForPakrevdeVedlegg = (
-    vedleggsobjekt: Vedleggsobjekt
-  ) => {
-    const markert = valgteVedlegg
-      .filter(v => v._key === vedleggsobjekt._key)
-      .filter(v => v.soknadsobjektId === soknadsobjekt._id)
-      .filter(v => !v.skalEttersendes)
-      .shift();
-    return sjekkboksPanelPropsForVedlegg(vedleggsobjekt, intl.locale, !!markert);
-  };
-
-  const lagCheckboks = (vedleggsobjekt: Vedleggsobjekt) => {
-    const markert = valgteVedlegg
-      .filter(v => v._key === vedleggsobjekt._key)
-      .filter(v => v.soknadsobjektId === soknadsobjekt._id)
-      .filter(v => v.skalSendes)
-      .shift();
-    return sjekkboksPanelPropsForVedlegg(vedleggsobjekt, intl.locale, !!markert);
-  };
-
-
   const vedleggTilSoknad = soknadsobjekt.vedleggtilsoknad || [];
-  const pakrevde = vedleggTilSoknad.filter(v => v.pakrevd);
-  return vedleggTilSoknad.length > 0 ? (
+  if (vedleggTilSoknad.length < 1) {
+    return null;
+  }
+  return (
     <PanelBase className="seksjon">
-      {skillUtPakrevde && pakrevde.length > 0 ? (
-        <>
-          <CheckboksPanelGruppe
-            className="sjekkbokser__panelgruppe"
-            legend={intl.formatMessage({id: "sjekkbokser.pakrevde"})}
-            checkboxes={vedleggTilSoknad
-              .filter(v => v.pakrevd)
-              .map(vedlegg => lagEgenCheckboksForPakrevdeVedlegg(vedlegg))}
-            onChange={handleOnChangePakrevdeVedlegg}
-          />
-          <CheckboksPanelGruppe
-            legend={intl.formatMessage({
-              id: "sjekkbokser.situasjonsbestemte"
-            })}
-            checkboxes={vedleggTilSoknad
-              .filter(v => !v.pakrevd)
-              .map(vedlegg => lagCheckboks(vedlegg))}
-            onChange={handleOnChange}
-          />
-        </>
-      ) : (
-        <CheckboksPanelGruppe
-          legend=""
-          checkboxes={vedleggTilSoknad.map(vedlegg => lagCheckboks(vedlegg))}
-          onChange={handleOnChange}
-        />
-      )}
+      <CheckboksPanelGruppe
+        legend=""
+        checkboxes={vedleggTilSoknad.map(vedlegg => sjekkboksPanelPropsForVedlegg(
+          vedlegg,
+          intl.locale,
+          skalSendes(vedlegg, valgteVedlegg, soknadsobjekt)))}
+        onChange={createChangeHandler(toggleValgtVedleggForSjekkbokser, soknadsobjekt)}
+      />
     </PanelBase>
-  ) : null;
+  );
 };
 
 const mapStateToProps = (store: Store) => ({
@@ -125,11 +95,75 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(toggleInnsendingVedlegg(_key, soknadsobjektId))
 });
 
-export default injectIntl<Props & InjectedIntlProps>(
+const SjekkbokserMedUtskiltePaakrevde = (props: MergedProps) => {
+  const {
+    intl,
+    soknadsobjekt,
+    valgteVedlegg,
+    toggleValgtVedleggForSjekkbokser,
+    toggleInnsendingVedlegg
+  } = props;
+  const vedleggTilSoknad = soknadsobjekt.vedleggtilsoknad || [];
+  if (vedleggTilSoknad.length < 1) {
+    return null;
+  }
+  const pakrevde = vedleggTilSoknad.filter(v => v.pakrevd);
+  if (pakrevde.length < 1) {
+    return <Sjekkbokser {...props} />;
+  }
+  // Dersom påkrevde vedlegg er i egen bolk
+  const lagEgenCheckboksForPakrevdeVedlegg = (
+    vedleggsobjekt: Vedleggsobjekt
+  ) => {
+    const markert = valgteVedlegg
+      .filter(v => v._key === vedleggsobjekt._key)
+      .filter(v => v.soknadsobjektId === soknadsobjekt._id)
+      .filter(v => !v.skalEttersendes)
+      .shift();
+    return sjekkboksPanelPropsForVedlegg(vedleggsobjekt, intl.locale, !!markert);
+  };
+
+  return (
+    <PanelBase className="seksjon">
+      <CheckboksPanelGruppe
+        className="sjekkbokser__panelgruppe"
+        legend={intl.formatMessage({id: "sjekkbokser.pakrevde"})}
+        checkboxes={vedleggTilSoknad
+          .filter(v => v.pakrevd)
+          .map(vedlegg => lagEgenCheckboksForPakrevdeVedlegg(vedlegg))}
+        onChange={createChangeHandler(toggleInnsendingVedlegg, soknadsobjekt)}
+      />
+      <CheckboksPanelGruppe
+        legend={intl.formatMessage({
+          id: "sjekkbokser.situasjonsbestemte"
+        })}
+        checkboxes={vedleggTilSoknad
+          .filter(v => !v.pakrevd)
+          .map(vedlegg => lagCheckboks(vedlegg, valgteVedlegg, soknadsobjekt, intl.locale))}
+        onChange={createChangeHandler(toggleValgtVedleggForSjekkbokser, soknadsobjekt)}
+      />
+    </PanelBase>
+  );
+};
+
+
+const WrappedSjekkBokserMedUtskiltePaakrevde = injectIntl<Props & InjectedIntlProps>(
+  withRouter<Props & InjectedIntlProps & RouteComponentProps, any>(
+    connect(
+      mapStateToProps,
+      mapDispatchToProps
+    )(SjekkbokserMedUtskiltePaakrevde)
+  )
+);
+
+const WrappedSjekkbokser = injectIntl<Props & InjectedIntlProps>(
   withRouter<Props & InjectedIntlProps & RouteComponentProps, any>(
     connect(
       mapStateToProps,
       mapDispatchToProps
     )(Sjekkbokser)
   )
-);
+)
+
+export {WrappedSjekkBokserMedUtskiltePaakrevde as SjekkbokserMedUtskiltePaakrevde, WrappedSjekkbokser as Sjekkbokser};
+

--- a/src/sider/3-soknadstilpasser/felles/velgvedlegg/Sjekkbokser.tsx
+++ b/src/sider/3-soknadstilpasser/felles/velgvedlegg/Sjekkbokser.tsx
@@ -1,20 +1,19 @@
-import React, { SyntheticEvent } from "react";
-import { injectIntl, InjectedIntlProps } from "react-intl";
-import { Vedleggsobjekt } from "typer/skjemaogvedlegg";
-import { Dispatch } from "redux";
-import { toggleInnsendingVedlegg } from "states/reducers/vedlegg";
-import { toggleValgtVedleggForSjekkbokser } from "states/reducers/vedlegg";
-import { Store } from "typer/store";
-import { Soknadsobjekt } from "typer/soknad";
-import { withRouter, RouteComponentProps } from "react-router";
-import { connect } from "react-redux";
+import React, {SyntheticEvent} from "react";
+import {injectIntl, InjectedIntlProps} from "react-intl";
+import {Vedleggsobjekt} from "typer/skjemaogvedlegg";
+import {Dispatch} from "redux";
+import {toggleInnsendingVedlegg} from "states/reducers/vedlegg";
+import {toggleValgtVedleggForSjekkbokser} from "states/reducers/vedlegg";
+import {Store} from "typer/store";
+import {Soknadsobjekt} from "typer/soknad";
+import {withRouter, RouteComponentProps} from "react-router";
+import {connect} from "react-redux";
 import PanelBase from "nav-frontend-paneler";
 import CheckboksPanelGruppe from "nav-frontend-skjema/lib/checkboks-panel-gruppe";
-import { localeTekst } from "utils/sprak";
-import { localeVedleggstittel } from "utils/soknadsobjekter";
+import {localeVedleggstittel} from "utils/soknadsobjekter";
 
 interface Props {
-  soknadsobjekt?: Soknadsobjekt;
+  soknadsobjekt: Soknadsobjekt;
   skillUtPakrevde?: boolean;
 }
 
@@ -27,41 +26,28 @@ interface ReduxProps {
   toggleInnsendingVedlegg: (_key: string, soknadsobjektId: string) => void;
 }
 
+const sjekkboksPanelPropsForVedlegg = (vedleggsobjekt: Vedleggsobjekt, locale: string, markert: boolean) => {
+  return {
+    key: vedleggsobjekt._key,
+    label: localeVedleggstittel(vedleggsobjekt, locale),
+    value: vedleggsobjekt._key,
+    checked: markert
+  };
+}
+
 type MergedProps = Props & InjectedIntlProps & RouteComponentProps & ReduxProps;
-const Sjekkbokser = (props: MergedProps) => {
-  const {
-    intl,
-    soknadsobjekt,
-    valgteVedlegg,
-    toggleValgtVedleggForSjekkbokser,
-    toggleInnsendingVedlegg
-  } = props;
-
-  if (!soknadsobjekt) {
-    return null;
-  }
-
+const Sjekkbokser = ({
+                       intl,
+                       soknadsobjekt,
+                       valgteVedlegg,
+                       toggleValgtVedleggForSjekkbokser,
+                       toggleInnsendingVedlegg,
+                       skillUtPakrevde
+                     }: MergedProps) => {
   const handleOnChange = (
     event: SyntheticEvent<EventTarget, Event>,
     value?: string
   ) => value && toggleValgtVedleggForSjekkbokser(value, soknadsobjekt._id);
-
-  const lagCheckboks = (vedleggsobjekt: Vedleggsobjekt) => {
-    const { _key } = vedleggsobjekt;
-
-    const markert = valgteVedlegg
-      .filter(v => v._key === _key)
-      .filter(v => v.soknadsobjektId === soknadsobjekt._id)
-      .filter(v => v.skalSendes)
-      .shift();
-
-    return {
-      key: _key,
-      label: localeVedleggstittel(vedleggsobjekt, intl.locale),
-      value: _key,
-      checked: !!markert
-    };
-  };
 
   // Dersom påkrevde vedlegg er i egen bolk
   const handleOnChangePakrevdeVedlegg = (
@@ -75,33 +61,33 @@ const Sjekkbokser = (props: MergedProps) => {
   const lagEgenCheckboksForPakrevdeVedlegg = (
     vedleggsobjekt: Vedleggsobjekt
   ) => {
-    const { vedlegg, _key } = vedleggsobjekt;
-    const { navn } = vedlegg;
-    const label = navn;
-
     const markert = valgteVedlegg
-      .filter(v => v._key === _key)
+      .filter(v => v._key === vedleggsobjekt._key)
       .filter(v => v.soknadsobjektId === soknadsobjekt._id)
       .filter(v => !v.skalEttersendes)
       .shift();
-
-    return {
-      key: _key,
-      label: localeTekst(label, intl.locale),
-      value: _key,
-      checked: !!markert
-    };
+    return sjekkboksPanelPropsForVedlegg(vedleggsobjekt, intl.locale, !!markert);
   };
+
+  const lagCheckboks = (vedleggsobjekt: Vedleggsobjekt) => {
+    const markert = valgteVedlegg
+      .filter(v => v._key === vedleggsobjekt._key)
+      .filter(v => v.soknadsobjektId === soknadsobjekt._id)
+      .filter(v => v.skalSendes)
+      .shift();
+    return sjekkboksPanelPropsForVedlegg(vedleggsobjekt, intl.locale, !!markert);
+  };
+
 
   const vedleggTilSoknad = soknadsobjekt.vedleggtilsoknad || [];
   const pakrevde = vedleggTilSoknad.filter(v => v.pakrevd);
   return vedleggTilSoknad.length > 0 ? (
     <PanelBase className="seksjon">
-      {props.skillUtPakrevde && pakrevde.length > 0 ? (
+      {skillUtPakrevde && pakrevde.length > 0 ? (
         <>
           <CheckboksPanelGruppe
             className="sjekkbokser__panelgruppe"
-            legend={intl.formatMessage({ id: "sjekkbokser.pakrevde" })}
+            legend={intl.formatMessage({id: "sjekkbokser.pakrevde"})}
             checkboxes={vedleggTilSoknad
               .filter(v => v.pakrevd)
               .map(vedlegg => lagEgenCheckboksForPakrevdeVedlegg(vedlegg))}

--- a/src/sider/3-soknadstilpasser/felles/velgvedlegg/Sjekkbokser.tsx
+++ b/src/sider/3-soknadstilpasser/felles/velgvedlegg/Sjekkbokser.tsx
@@ -20,7 +20,7 @@ type ToggleFunc = (_key: string, soknadsobjektId: string) => void;
 interface ReduxProps {
   valgteVedlegg: Vedleggsobjekt[];
   toggleValgtVedleggForSjekkbokser: ToggleFunc;
-  toggleInnsendingVedlegg: (_key: string, soknadsobjektId: string) => void;
+  toggleInnsendingVedlegg: ToggleFunc;
 }
 
 const sjekkboksPanelPropsForVedlegg = (vedleggsobjekt: Vedleggsobjekt, locale: string, markert: boolean) => {

--- a/src/sider/3-soknadstilpasser/soknad/Soknad.tsx
+++ b/src/sider/3-soknadstilpasser/soknad/Soknad.tsx
@@ -10,7 +10,7 @@ import { Element, Normaltekst } from "nav-frontend-typografi";
 import { ToggleGruppe, ToggleKnappPureProps } from "nav-frontend-toggle";
 import VeiledendeVedleggsvalg from "../felles/velgvedlegg/VeiledendeVedleggsvalg";
 import DineVedlegg from "../felles/dinevedlegg/DineVedlegg";
-import Sjekkbokser from "../felles/velgvedlegg/Sjekkbokser";
+import {SjekkbokserMedUtskiltePaakrevde} from "../felles/velgvedlegg/Sjekkbokser";
 import Personalia from "../felles/personalia/Personalia";
 import { Store } from "../../../typer/store";
 import { medValgtSoknadsobjekt } from "../../../states/providers/ValgtSoknadsobjekt";
@@ -185,9 +185,8 @@ const Soknad = (props: MergedProps) => {
                 </>
               ) : (
                 <>
-                  <Sjekkbokser
+                  <SjekkbokserMedUtskiltePaakrevde
                     soknadsobjekt={valgtSoknadsobjekt}
-                    skillUtPakrevde={true}
                   />
                   {tilDokumentinnsending ? (
                     <Neste


### PR DESCRIPTION
Bruk koden som bruker alternative titler til å vise vedlegg uansett.

Fikser https://trello.com/c/6yGsbWbP/161-visning-av-vedleggsnavn-med-alternative-titler-vises-ikke-n%C3%A5r-uten-hjelp-til-vedlegg