### PR TITLE
Varsling av feil ved generering av førstesideark - engelsk

### DIFF
--- a/src/sprak/tekster/en.ts
+++ b/src/sprak/tekster/en.ts
@@ -25,7 +25,7 @@ export default {
   "avslutning.steg.forsteside.tittel": `Download the cover sheet for your application`,
   "avslutning.steg.forsteside.pdf.tittel": `Cover sheet`,
   "avslutning.steg.forsteside.beskrivelse": `The cover sheet contains important information about the <b>NAV unit</b> that will receive the documents. It also contains the address to which the documents should be sent.`,
-  "avslutning.steg.forsteside.nedlastingsfeil": `Something went wrong. Try again later. We are working to correct the error.`,
+  "avslutning.steg.forsteside.nedlastingsfeil": `Something went wrong. Make sure you have entered the correct Norwegian national identity number / D-number and try again.`,
   "avslutning.steg.forsteside.nedlastingsfeil.hotjartrigger": `Help us understand what went wrong.`,
   "avslutning.steg.nedlasting.skjema.tittel": `Download the application form {skjemanummer}`,
   "avslutning.steg.nedlasting.skjema.beskrivelse": `The application form must be filled out and signed.`,


### PR DESCRIPTION
Trigging av Hotjar og spørsmåls teksten nedenfor må fjernes
"avslutning.steg.forsteside.nedlastingsfeil.hotjartrigger": `Hjelp oss å forstå hva feilen er.`,
"avslutning.steg.forsteside.nedlastingsfeil.hotjartrigger": `Help us understand what went wrong.`,