### PR TITLE
Oppdaterer url til ettersending

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,16 @@ export const getTjenesteUrl = (): string => {
   }
 };
 
+export const getEttersendingUrl = (): string => {
+  if (window.location.href.indexOf("soknadsveiviser-q0") !== -1) {
+    return "https://www.intern.dev.nav.no/person/ettersende";
+  } else if (window.location.href.indexOf("soknadsveiviser-q1") !== -1) {
+    return "https://www.intern.dev.nav.no/person/ettersende";
+  } else {
+    return "https://www.nav.no/person/ettersende";
+  }
+};
+
 export const getSendInnHost = (): string => {
   if (window.location.href.indexOf("soknadsveiviser-q0") !== -1) {
     return "https://www.dev.nav.no";

--- a/src/sider/2-soknadsvelger/seksjoner/HovedSoknadsobjekt.tsx
+++ b/src/sider/2-soknadsvelger/seksjoner/HovedSoknadsobjekt.tsx
@@ -4,7 +4,7 @@ import Undertittel from "nav-frontend-typografi/lib/undertittel";
 import { injectIntl, InjectedIntlProps, FormattedMessage } from "react-intl";
 import BlockContent from "@sanity/block-content-to-react";
 import RelevantInformasjon from "./RelevantInformasjon";
-import { getTjenesteUrl } from "../../../config";
+import { getEttersendingUrl } from "../../../config";
 import { link } from "../../../utils/serializers";
 import { Normaltekst } from "nav-frontend-typografi";
 import { HashLink } from "react-router-hash-link";
@@ -69,7 +69,7 @@ const HovedSoknadsobjekt = (props: Props & InjectedIntlProps) => {
               ettersendelse.ettersendelsesURL &&
               ettersendelse.ettersendelsesURL.nb
                 ? localeTekst(ettersendelse.ettersendelsesURL, locale)
-                : `${getTjenesteUrl()}/saksoversikt/ettersending`
+                : getEttersendingUrl()
             }
             className="soknadsobjekt__knapp knapp knapp-hoved"
           >

--- a/src/sider/3-soknadstilpasser/ettersendelse/DigitalEllerPapirEttersendelse.tsx
+++ b/src/sider/3-soknadstilpasser/ettersendelse/DigitalEllerPapirEttersendelse.tsx
@@ -9,7 +9,7 @@ import { localeTekst } from "../../../utils/sprak";
 import { finnesDigitalEttersendelse, finnesDokumentinnsending } from "../../../utils/soknadsobjekter";
 import { medValgtSoknadsobjekt } from "../../../states/providers/ValgtSoknadsobjekt";
 import { sideTittel } from "../../../utils/sprak";
-import { getTjenesteUrl } from "../../../config";
+import { getEttersendingUrl } from "../../../config";
 import { Redirect } from "react-router-dom";
 import { kanKlage } from "../../../utils/kanKlage";
 import Helmet from "react-helmet";
@@ -98,5 +98,5 @@ const hentDigitalEttersendelsesURL = (soknadsobjekt: Soknadsobjekt, locale: stri
     soknadsobjekt.digitalinnsending.inngangtilsoknadsdialog.ettersendelse.ettersendelsesURL &&
     soknadsobjekt.digitalinnsending.inngangtilsoknadsdialog.ettersendelse.ettersendelsesURL.nb
     ? localeTekst(soknadsobjekt.digitalinnsending.inngangtilsoknadsdialog.ettersendelse.ettersendelsesURL, locale)
-    : `${getTjenesteUrl()}/saksoversikt/ettersending`;
+    : getEttersendingUrl();
 };


### PR DESCRIPTION
I dag så ligger det en redirect i appen for ettersending som redirecter fra en gammel saksoversikt URL til ettersending. Denne redirecten skal fjernes snart, så derfor må det lenkes direkte til ettersending.